### PR TITLE
Python3 update

### DIFF
--- a/pfb.py
+++ b/pfb.py
@@ -162,12 +162,14 @@ def inverse_pfb(ts_pfb, ntap, window=sinc_hanning, no_nyquist=False):
     ntsblock = nblock + ntap - 1
 
     # Coefficients for the P matrix
-    coeff_P = window(ntap, lblock).reshape(ntap, lblock)  # Create the window array
+    # Create the window array.
+    coeff_P = window(ntap, lblock).reshape(ntap, lblock)
 
     # Coefficients for the PP^T matrix
-    coeff_PPT = np.array([ (  coeff_P[:, np.newaxis, :]
-                            * coeff_P[np.newaxis, :, :] ).diagonal(offset=k).sum(axis=-1)
-                           for k in range(ntap) ])
+    coeff_PPT = np.array([(coeff_P[:, np.newaxis, :] *
+                           coeff_P[np.newaxis, :, :])
+                          .diagonal(offset=k).sum(axis=-1)
+                          for k in range(ntap)])
 
     rec_ts = np.zeros((lblock, ntsblock), dtype=np.float64)
 
@@ -193,7 +195,8 @@ def inverse_pfb(ts_pfb, ntap, window=sinc_hanning, no_nyquist=False):
     return rec_ts
 
 
-def inverse_pfb_parallel(ts_pfb, ntap, nblock, window=sinc_hanning, no_nyquist=False, skip_initial_blocks=True):
+def inverse_pfb_parallel(ts_pfb, ntap, nblock, window=sinc_hanning,
+                         no_nyquist=False, skip_initial_blocks=True):
     """Invert the CHIME PFB timestream.
 
     Parameters
@@ -236,17 +239,19 @@ def inverse_pfb_parallel(ts_pfb, ntap, nblock, window=sinc_hanning, no_nyquist=F
     local_off, start_off, end_off = mpiutil.split_local(lblock)
 
     # Coefficients for the P matrix
-    coeff_P = window(ntap, lblock).reshape(ntap, lblock)[:, start_off:end_off]  # Create the window array
+    # Create the window array
+    coeff_P = window(ntap, lblock).reshape(ntap, lblock)[:, start_off:end_off]
 
     # Coefficients for the PP^T matrix
-    coeff_PPT = np.array([ (  coeff_P[:, np.newaxis, :]
-                            * coeff_P[np.newaxis, :, :] ).diagonal(offset=k).sum(axis=-1)
-                           for k in range(ntap) ])
+    coeff_PPT = np.array([(coeff_P[:, np.newaxis, :] *
+                           coeff_P[np.newaxis, :, :])
+                          .diagonal(offset=k).sum(axis=-1)
+                          for k in range(ntap)])
 
     ax2size = nblock if skip_initial_blocks else ntsblock
     rec_ts = np.zeros((local_off, ax2size), dtype=np.float64)
 
-#    print mpiutil.rank, local_off, pseudo_ts.shape, coeff_P.shape
+    #  print mpiutil.rank, local_off, pseudo_ts.shape, coeff_P.shape
 
     for i_off in range(local_off):
 

--- a/pfb.py
+++ b/pfb.py
@@ -106,7 +106,7 @@ def pfb(timestream, nfreq, ntap=4, window=sinc_hanning):
     lblock = 2 * (nfreq - 1)
 
     # Number of blocks
-    nblock = timestream.size / lblock - (ntap - 1)
+    nblock = timestream.size // lblock - (ntap - 1)
 
     # Initialise array for spectrum
     spec = np.zeros((nblock, nfreq), dtype=np.complex128)
@@ -207,7 +207,7 @@ def inverse_pfb_parallel(ts_pfb, ntap, nblock, window=sinc_hanning, no_nyquist=F
     no_nyquist : boolean, optional
         If True, we are missing the Nyquist frequency (i.e. CHIME PFB), and we
         should add it back in (with zero amplitude).
-    skip_initial_blocks : boolean, optional    
+    skip_initial_blocks : boolean, optional
         If True (default), throw away the initial, heavily unconstrained
         blocks of samples.
     """
@@ -275,4 +275,3 @@ def inverse_pfb_parallel(ts_pfb, ntap, nblock, window=sinc_hanning, no_nyquist=F
     rec_ts = rec_ts.T.copy()
 
     return rec_ts
-


### PR DESCRIPTION
@jrs65 - we're getting back to actually dechannelizing. This PR just adds a floor divide for `nblock` so the code runs under python3, and a few PEP8 changes so I don't see red wiggly lines when I open pfb.py.

Am still rather puzzled at how the deviations in the inverse don't just stay low, but rise towards the end. Logically, this really should not happen: at the end, you have even more information on what came before than in the middle, so, if anything, the inverse should be better.
